### PR TITLE
Makefile creates OBJ_DIR if it does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ quokka: $(OBJ_FILES)
 	   g++ -O2 -o $@ $^ -lpthread
 
 $(OBJ_DIR)/%.o: $(SRC_DIR)/%.cpp
+	   mkdir -p $(dir $@)
 	   g++ -O2 $(CXXFLAGS) -c $< -o $@ -lpthread
 
 clean:


### PR DESCRIPTION
Resolves #5 by having the Makefile create the directory specified by `$(OBJ_DIR)` if it does not exist. Also brought up as an issue in #4.